### PR TITLE
Support symbol strings with '_' in place of '+'

### DIFF
--- a/X11Exception.h
+++ b/X11Exception.h
@@ -13,7 +13,7 @@ class X11Exception : public std::exception
 {
 public:
     X11Exception() : _reason("unknown") {}
-    X11Exception(const std::string& what) : _reason(what) {}
+    explicit X11Exception(const std::string& what) : _reason(what) {}
     virtual ~X11Exception() throw () {};
     virtual const char* what() const throw () { return _reason.c_str(); }
 
@@ -21,9 +21,8 @@ private:
     std::string _reason;
 };
 
-#endif // GAMEEXCEPTION_H_FE39A315_6827_447B_AE62_5FA2C3FD391F
+#endif // X11EXCEPTION_H_FE39A315_6827_447B_AE62_5FA2C3FD391F
 
 // Local Variables:
 // mode: c++
 // End:
-

--- a/XKeyboard.cpp
+++ b/XKeyboard.cpp
@@ -124,7 +124,7 @@ Bool XKeyboard::initializeXkb()
                 groupName = groupNameC;
                 std::string::size_type pos = groupName.find('(', 0);
                 if (pos != std::string::npos) {
-                    groupName = groupName.substr(0, pos + 1);
+                    groupName = groupName.substr(0, pos - 1);
                 }
                 _groupNames.push_back(groupName);
             }

--- a/XKeyboard.cpp
+++ b/XKeyboard.cpp
@@ -327,7 +327,7 @@ void XkbSymbolParser::parse(const std::string& symbols, StringVector& symbolList
     
     for (size_t i = 0; i < symbols.size(); i++) {
         char ch = symbols[i];
-        if (ch == '+') {
+        if (ch == '+' || ch == '_') {
             if (inSymbol) {
                 if (isXkbLayoutSymbol(curSymbol)) {
                     symbolList.push_back(curSymbol);

--- a/wrapper.cpp
+++ b/wrapper.cpp
@@ -59,7 +59,7 @@ bool print_status(XKeyboard& xkb, string format) {
     stringstream r;     // resulting string
 
     for (size_t i = 0; i < format.length(); ++i) {
-        if (format[i] == '%' && i < format.length()-1) {
+        if (i < format.length()-2 && format[i] == '%') {
             switch (format[i+1]) {
                 case 'c':
                     r << xkb.currentGroupNum();
@@ -180,8 +180,8 @@ int main(int argc, char* argv[])
             }
         }
     }
-    catch (exception e) {
-        cerr << e.what() << endl;
+    catch (const exception *e) {
+        cerr << e->what() << endl;
         return EXIT_FAILURE;
     }
     return EXIT_SUCCESS;


### PR DESCRIPTION
This fixes a segfault that occurs for the following reason:
- In XKeyboard::initializeXkb(), the XkbSymbolParser::parse() is called
  with three arguments - string to process (symName),
  vector to push symbol names to (_symbolNames)
  and vector to push variant names to (_variantNames).
- In XkbSymbolParser::parse(), it looks for char '+' in symName string,
  but Xkb may use '_' instead when creating that string. If the char
  is not found, parse() doesn't append anything to vectors and they
  remain empty.
- Later, XKeyboard::initializeXkb() tries to access nonexistent data in
  _symbolNames, which causes a segmentation fault (on lines 162-163).
