### PR TITLE
Fix linking with --as-needed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,23 +2,25 @@ CXXFLAGS ?= -O2
 
 PREFIX ?= /usr/local
 
-all: xkblayout-state
+headers := XKeyboard.h X11Exception.h
+sources := XKeyboard.cpp wrapper.cpp
+objects := $(sources:.cpp=.o)
+program := xkblayout-state
 
-XKeyboard.o: XKeyboard.cpp XKeyboard.h X11Exception.h
+all: $(program)
+
+$(objects): %.o: %.cpp $(headers)
 	$(CXX) $(CXXFLAGS) -Wall -c -o $@ $<
 
-wrapper.o: wrapper.cpp XKeyboard.h
-	$(CXX) $(CXXFLAGS) -Wall -c -o $@ $<
-
-xkblayout-state: XKeyboard.o wrapper.o
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) -lX11 -o xkblayout-state $^
+$(program): $(objects)
+	$(CXX) $(CXXFLAGS) -lX11 $(LDFLAGS) -o $@ $^
 
 clean:
-	rm -f xkblayout-state XKeyboard.o wrapper.o
+	rm -f $(program) $(objects)
 
-install: xkblayout-state
-	install xkblayout-state $(DESTDIR)$(PREFIX)/bin
+install: $(program)
+	install $(program) $(DESTDIR)$(PREFIX)/bin
 
 dist:
-	tar cfa xkblayout-state-v1b.tar.gz Makefile README.md wrapper.cpp X11Exception.h XKeyboard.cpp XKeyboard.h
+	tar cfa $(program)-v1b.tar.gz Makefile README.md $(headers) $(sources)
 


### PR DESCRIPTION
When passing `--as-needed` to the linker, `make` dies with
```
$ make LDFLAGS="-Wl,--as-needed"
c++ -O2 -Wall -c -o XKeyboard.o XKeyboard.cpp
c++ -O2 -Wall -c -o wrapper.o wrapper.cpp
c++ -O2 -Wl,--as-needed -lX11 -o xkblayout-state XKeyboard.o wrapper.o
XKeyboard.o: In function `XKeyboard::accomodateGroupXkb()':
XKeyboard.cpp:(.text+0xc2): undefined reference to `XkbGetState'
XKeyboard.o: In function `XKeyboard::~XKeyboard()':
XKeyboard.cpp:(.text+0xeb): undefined reference to `XCloseDisplay'
XKeyboard.o: In function `XKeyboard::currentGroupNum() const':
XKeyboard.cpp:(.text+0x50e): undefined reference to `XkbGetState'
XKeyboard.o: In function `XKeyboard::currentGroupName[abi:cxx11]() const':
XKeyboard.cpp:(.text+0x537): undefined reference to `XkbGetState'
XKeyboard.o: In function `XKeyboard::currentGroupSymbol[abi:cxx11]() const':
XKeyboard.cpp:(.text+0x587): undefined reference to `XkbGetState'
XKeyboard.o: In function `XKeyboard::currentGroupVariant[abi:cxx11]() const':
XKeyboard.cpp:(.text+0x5d7): undefined reference to `XkbGetState'
XKeyboard.o: In function `XKeyboard::setGroupByNum(int)':
XKeyboard.cpp:(.text+0x627): undefined reference to `XkbLockGroup'
XKeyboard.cpp:(.text+0x64a): undefined reference to `XkbGetState'
XKeyboard.o: In function `XKeyboard::changeGroup(int)':
XKeyboard.cpp:(.text+0x688): undefined reference to `XkbLockGroup'
XKeyboard.cpp:(.text+0x69c): undefined reference to `XkbGetState'
XKeyboard.o: In function `XKeyboard::initializeXkb()':
XKeyboard.cpp:(.text+0x131f): undefined reference to `XkbQueryExtension'
XKeyboard.cpp:(.text+0x1324): undefined reference to `XkbAllocKeyboard'
XKeyboard.cpp:(.text+0x135e): undefined reference to `XkbGetControls'
XKeyboard.cpp:(.text+0x136f): undefined reference to `XkbGetNames'
XKeyboard.cpp:(.text+0x1380): undefined reference to `XkbGetNames'
XKeyboard.cpp:(.text+0x141e): undefined reference to `XGetAtomName'
XKeyboard.cpp:(.text+0x1555): undefined reference to `XFree'
XKeyboard.cpp:(.text+0x1702): undefined reference to `XGetAtomName'
XKeyboard.cpp:(.text+0x1732): undefined reference to `XFree'
XKeyboard.cpp:(.text+0x1944): undefined reference to `XkbGetState'
XKeyboard.o: In function `XKeyboard::XKeyboard()':
XKeyboard.cpp:(.text+0x1c55): undefined reference to `XkbIgnoreExtension'
XKeyboard.cpp:(.text+0x1c90): undefined reference to `XkbOpenDisplay'
XKeyboard.cpp:(.text+0x1f0a): undefined reference to `XkbSelectEventDetails'
XKeyboard.cpp:(.text+0x1f1d): undefined reference to `XkbGetState'
XKeyboard.cpp:(.text+0x1f38): undefined reference to `XkbGetState'
collect2: error: ld returned 1 exit status
make: *** [Makefile:14: xkblayout-state] Error 1
```
The reason for this is that the order between `$(LDFLAGS)` and `-lX11` in the linking rule in `Makefile` were wrong. This pull request fixes this as well as removes all hardcoding in the `Makefile`. The un-hardcoding is quite extreme (there are no repetitions left) so if you would rather go with the previous variant, I can revise the PR.