### PR TITLE
Fix install when the destination does not exist.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ clean:
 	rm -f $(program) $(objects)
 
 install: $(program)
-	install $(program) $(DESTDIR)$(PREFIX)/bin
+	install -D -t $(DESTDIR)$(PREFIX)/bin $(program)
 
 dist:
 	tar cfa $(program)-v1b.tar.gz Makefile README.md $(headers) $(sources)


### PR DESCRIPTION
Currently, the installation fails if the target directory does not exists. This should be the last commit before I can get a Gentoo package in place.