### PR TITLE
-lX11 needs to be at the end when linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ $(objects): %.o: %.cpp $(headers)
 	$(CXX) $(CXXFLAGS) -Wall -c -o $@ $<
 
 $(program): $(objects)
-	$(CXX) $(CXXFLAGS) -lX11 $(LDFLAGS) -o $@ $^
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $^ -lX11
 
 clean:
 	rm -f $(program) $(objects)


### PR DESCRIPTION
when linking, if I did not have -lX11 at the end, it couldnt find the X11 objects.